### PR TITLE
CORS control

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,12 +31,12 @@ module.exports.transport = {
 		return transport;
 	},
 
-	HTTP: function(httpServer, expressApp) {
+	HTTP: function(httpServer, expressApp, options) {
 		if (!httpServer || !expressApp) {
 			throw new Error('HTTP transport requires an HTTP server and an Express application instance.');
 		}
 		var transport = require("./lib/rest-transport");
-		transport = new transport(httpServer, expressApp);
+		transport = new transport(httpServer, expressApp, options);
 		transport.trace = new Trace(debugLogger);
 		return transport;
 	}

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -164,14 +164,21 @@ ServiceRegistry.prototype.renderMetadataPage = function (service, req, res) {
 	}
 };
 
-ServiceRegistry.prototype.router = function () {
-	var self = this;
+/**
+ * @param {object} [options]
+ * @param {boolean} [options.disableCors=false]
+ */
+ServiceRegistry.prototype.router = function (options) {
+	var self = this, options = options || {};
+
+	options.disableCors = !!options.disableCors;
+
 	return function (req, res, next) {
 		var url = req.path.replace(/\/\//ig, '/').replace(/\/*$/gi, '');
 		url = require('url').parse(url).pathname || '';
 		//console.log('root = ' + self.rootPath + ', url = ' + url);
 
-		if (req.method.toUpperCase() == 'OPTIONS' && url.substr(0, self.rootPath.length) == self.rootPath) {
+		if (!options.disableCors && req.method.toUpperCase() == 'OPTIONS' && url.substr(0, self.rootPath.length) == self.rootPath) {
 			res.set('Access-Control-Allow-Origin', '*');
 			res.set('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
 			res.set('Access-Control-Max-Age', 1000);

--- a/lib/rest-transport.js
+++ b/lib/rest-transport.js
@@ -25,8 +25,12 @@ function param(req, name, defaultValue) {
 	return defaultValue;
 }
 
-var RestTransport = module.exports = function RestTransport(httpServer, expressApp) {
+var RestTransport = module.exports = function RestTransport(httpServer, expressApp, options) {
 	Transport.call(this);
+
+	this.options = options || {};
+	this.options.disableCors = !!this.options.disableCors;
+
 	this.srv = httpServer;
 	this.app = expressApp;
 	this.name = 'HTTP';
@@ -69,7 +73,11 @@ RestTransport.prototype.close = function() {
 // HTTP-specific sendMessage
 RestTransport.prototype.sendMessage = function(msg, context, format) {
 	var res = context.http.response;
-	res.set('Access-Control-Allow-Origin', '*');
+
+	if (!this.options.disableCors) {
+		res.set('Access-Control-Allow-Origin', '*');
+	}
+
 	var isSent = false;
 	try {
 		if (msg.error) {


### PR DESCRIPTION
Make sending of CORS-related headers optional. This allows the main app (the app that makes use of json-ws) to implement custom CORS strategy.