### PR TITLE
Custom XHR options 

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -427,6 +427,15 @@
 			});
 		} else {
 			var xhr = new XMLHttpRequest();
+			
+			if (this.sslSettings.xhrFields) {
+				for (var s in this.sslSettings.xhrFields) {
+					if (this.sslSettings.xhrFields.hasOwnProperty(s)) {
+						xhr[s] = this.sslSettings.xhrFields[s];
+					}
+				}
+			}
+			
 			xhr.open('POST', this.url, true);
 			xhr.responseType = 'arraybuffer';
 			xhr.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');


### PR DESCRIPTION
When using JavaScript proxy with HTTP transport, I couldn't find a way to set properties of the underlying XmlHttpRequest object (the property I had to change is `withCredentials: true`, since I need to send cookies along with CORS requests.

The proposed change allows setting those options at client proxy creation time:

```javascript
var proxy = new Proxy(url, {
    xhrFields: {
        withCredentials: true
        // ...
    }
});
```