### PR TITLE
Set xhr fields after xhr.open (ie10 compat)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -427,6 +427,8 @@
 			});
 		} else {
 			var xhr = new XMLHttpRequest();
+
+			xhr.open('POST', this.url, true);
 			
 			if (this.sslSettings.xhrFields) {
 				for (var s in this.sslSettings.xhrFields) {
@@ -436,7 +438,6 @@
 				}
 			}
 			
-			xhr.open('POST', this.url, true);
 			xhr.responseType = 'arraybuffer';
 			xhr.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
 			xhr.onreadystatechange = function () {


### PR DESCRIPTION
Some browsers (IE10, Safari 5) insist that setting `XHR.withCredentials` must be set **after** `XHR.open()`.

See [this Stackoverflow question](http://stackoverflow.com/questions/19666809/cors-withcredentials-support-limited) and [August 16, 2011 XHR draft](http://www.w3.org/TR/2011/WD-XMLHttpRequest2-20110816/#the-withcredentials-attribute)