### PR TITLE
Change type of enums in Go proxies.

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -36,10 +36,10 @@ const codes = {
 module.exports = ServiceError;
 
 module.exports.AsServiceError = (err, reporter, code, metadata) => {
-	code = code ? code : codes.InternalServerError;
+	code = (code || code === 0) ? code : codes.InternalServerError;
 
 	if (err instanceof ServiceError) {
-		err.code = err.code ? err.code : codes.InternalServerError;
+		err.code = (err.code || err.code === 0) ? err.code : codes.InternalServerError;
 		if (reporter && err.reporter !== reporter) {
 			return new ServiceError(reporter, code, {
 				message: err.message,
@@ -52,7 +52,7 @@ module.exports.AsServiceError = (err, reporter, code, metadata) => {
 
 	// Check for a JSON-RPC error.
 	if (err.hasOwnProperty('data')) {
-		return new ServiceError(reporter, codes.InternalServerError, {
+		return new ServiceError(reporter, code, {
 			message: err.data.message,
 			cause: err.data,
 			metadata,
@@ -60,13 +60,13 @@ module.exports.AsServiceError = (err, reporter, code, metadata) => {
 	}
 
 	if (err instanceof Error) {
-		return new ServiceError(reporter, codes.InternalServerError, {
+		return new ServiceError(reporter, code, {
 			message: err.message,
 			metadata,
 		});
 	}
 
-	return new ServiceError(reporter, codes.InternalServerError, {
+	return new ServiceError(reporter, code, {
 		message: err,
 		metadata,
 	});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-ws",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "author": "ChaosGroup (c) 2013-2017",
   "description": "JSON-RPC based Web Services with automatic help and client side source creation for Node.js/Go/JavaScript/Java/.Net/Python/PHP",
   "keywords": [

--- a/proxies/Go.ejs
+++ b/proxies/Go.ejs
@@ -197,7 +197,7 @@ function generateTypes() {
 			const structFields = formatColumns(_.map(type.struct, (property, propertyName) => {
 				return [`${pascalCase(propertyName)}${typeName}`, typeName, `= ${property}`];
 			}), '\n\t');
-			result += `\ntype ${typeName} int64\n\nconst (\n\t${structFields}\n)\n`;
+			result += `\ntype ${typeName} int\n\nconst (\n\t${structFields}\n)\n`;
 		} else {
 			const structFields = formatColumns(_.map(type.struct, (property, propertyName) => {
 				let jsonTag = propertyName;

--- a/proxies/Go.ejs
+++ b/proxies/Go.ejs
@@ -198,6 +198,10 @@ function generateTypes() {
 				return [`${pascalCase(propertyName)}${typeName}`, typeName, `= ${property}`];
 			}), '\n\t');
 			result += `\ntype ${typeName} int\n\nconst (\n\t${structFields}\n)\n`;
+
+			const selfName = '__self__';
+			result += `func (${selfName} ${typeName}) Value() int {\n\treturn int(${selfName})\n}`;
+
 		} else {
 			const structFields = formatColumns(_.map(type.struct, (property, propertyName) => {
 				let jsonTag = propertyName;

--- a/test/lib/error.js
+++ b/test/lib/error.js
@@ -28,7 +28,7 @@ describe('Converter', function() {
 		expect(actual.message).to.equal(MESSAGE);
 	});
 
-	it('returns ServiceError with default error code', function() {
+	it('returns ServiceError with InternalServerError code', function() {
 		const error = new ServiceError(REPORTER, undefined, {});
 
 		const actual = AsServiceError(error);
@@ -45,6 +45,22 @@ describe('Converter', function() {
 		expect(actual.reporter).to.equal(REPORTER);
 		expect(actual.code).to.equal(DEFAULT_ERROR_CODE);
 		expect(actual.cause).to.equal(error);
+	});
+
+	it('returns ServiceError with zero error code', function() {
+		const actual = AsServiceError("something went wrong", REPORTER, 0);
+		expect(actual).to.be.an.instanceof(ServiceError);
+		expect(actual.reporter).to.equal(REPORTER);
+		expect(actual.code).to.equal(0);
+	});
+
+	it('wraps ServiceError with zero error code', function() {
+		const error = new ServiceError(REPORTER, 0, {});
+
+		const actual = AsServiceError(error, REPORTER);
+		expect(actual).to.be.an.instanceof(ServiceError);
+		expect(actual.reporter).to.equal(REPORTER);
+		expect(actual.code).to.equal(0);
 	});
 
 	it('wraps Error', function() {


### PR DESCRIPTION
* The type of Go enums is changed from `int64` to `int`. Also, a method is generated for each enumerable which casts the enumerated value to `int`.

* A bug is fixed in the error utilities - the default error code `0` was not handled correctly by the `AsServiceError` helper.