### PR TITLE
Support older Safari browsers in the HTTP transport

### DIFF
--- a/lib/client/transports/http.js
+++ b/lib/client/transports/http.js
@@ -73,7 +73,8 @@
 
 	HttpTransport.prototype.send = function (message, callback) {
 		// checking for XMLHttpRequest first, it's the default for the browser
-		if (typeof XMLHttpRequest === 'function') {
+		// On older Safari browser the type of XMLHttpRequest is "object"...
+		if (typeof XMLHttpRequest === 'function' || typeof XMLHttpRequest === 'object') {
 			var xhr = new XMLHttpRequest();
 			xhr.open('POST', this.url, true);
 			if (this.settings.xhrFields) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-ws",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "author": "ChaosGroup (c) 2013-2018",
   "description": "JSON-RPC based Web Services with automatic help and client side source creation for Node.js/Go/JavaScript/Java/.Net/Python/PHP",
   "keywords": [


### PR DESCRIPTION
On the older Safari browsers the type of XMLHttpRequest is "object", not
"function".