### PR TITLE
Propagate the cause error code in all cases.

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -55,7 +55,7 @@ module.exports.AsServiceError = (err, reporter, code, metadata) => {
 	if (err instanceof ServiceError) {
 		err.code = err.code || err.code === 0 ? err.code : codes.InternalServerError;
 		if (reporter && err.reporter !== reporter) {
-			return new ServiceError(reporter, code, {
+			return new ServiceError(reporter, err.code, {
 				message: err.message,
 				cause: err,
 				metadata,
@@ -66,6 +66,7 @@ module.exports.AsServiceError = (err, reporter, code, metadata) => {
 
 	// Check for a JSON-RPC error.
 	if (err.hasOwnProperty('data')) {
+		code = err.data.code || err.data.code === 0 ? err.data.code : code;
 		return new ServiceError(reporter, code, {
 			message: err.data.message,
 			cause: err.data,

--- a/test/unit/lib/error.js
+++ b/test/unit/lib/error.js
@@ -38,12 +38,12 @@ describe('Converter', function() {
 	});
 
 	it('wraps ServiceError with different reporter', function() {
-		const error = new ServiceError('different', 111, {});
+		const error = new ServiceError('different', CAUSE_CODE, {});
 
 		const actual = AsServiceError(error, REPORTER);
 		expect(actual).to.be.an.instanceof(ServiceError);
 		expect(actual.reporter).to.equal(REPORTER);
-		expect(actual.code).to.equal(DEFAULT_ERROR_CODE);
+		expect(actual.code).to.equal(CAUSE_CODE);
 		expect(actual.cause).to.equal(error);
 	});
 
@@ -90,7 +90,7 @@ describe('Converter', function() {
 		expect(actual.timestamp).to.be.ok;
 
 		expect(actual.reporter).to.equal(REPORTER);
-		expect(actual.code).to.equal(DEFAULT_ERROR_CODE);
+		expect(actual.code).to.equal(CAUSE_CODE);
 		expect(actual.message).to.equal(CAUSE_MESSAGE);
 
 		expect(actual.cause).to.be.defined;
@@ -116,7 +116,7 @@ describe('Converter', function() {
 		expect(actual.timestamp).to.be.ok;
 
 		expect(actual.reporter).to.equal(REPORTER);
-		expect(actual.code).to.equal(DEFAULT_ERROR_CODE);
+		expect(actual.code).to.equal(CAUSE_CODE);
 
 		expect(actual.cause).to.be.defined;
 		expect(actual.cause.reporter).to.equal(CAUSE_REPORTER);


### PR DESCRIPTION
When an error is being wrapped in our custom structure without explicitly passing a new error code, the error code from the error being wrapped should be used (if one exists). 