### PR TITLE
Correctly trace mutated errors

### DIFF
--- a/lib/transport/base-transport.js
+++ b/lib/transport/base-transport.js
@@ -268,9 +268,7 @@ class BaseTransport extends EventEmitter {
 				throw new Error('Method ' + methodInfo.name + ' has already sent a response.');
 			}
 
-			if (err) {
-				this.trace.error(context, methodInfo, err);
-			} else if (result) {
+			if (result) {
 				this.trace.response(context, methodInfo, result);
 			}
 
@@ -290,18 +288,18 @@ class BaseTransport extends EventEmitter {
 				} catch (resultConversionErr) {
 					errorData = 'Result conversion error: ' + resultConversionErr.message;
 					result = null;
-					this.trace.error(context, methodInfo, resultConversionErr);
 				}
 			} else {
 				result = null;
 			}
-			const error =
-				errorData &&
-				jsonrpc.error(
-					-32000,
-					'Internal server error',
-					AsServiceError(errorData, service.name)
-				);
+
+			let error;
+			if (errorData) {
+				const serviceErr = AsServiceError(errorData, service.name);
+				error = jsonrpc.error(-32000, 'Internal server error', serviceErr);
+				this.trace.error(context, methodInfo, serviceErr);
+			}
+
 			format = format || null;
 			this.sendMessage(jsonrpc.response(id, error, result), context, format);
 			responseIsSent = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-ws",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "author": "ChaosGroup (c) 2013-2018",
   "description": "JSON-RPC based Web Services with automatic help and client side source creation for Node.js/Go/JavaScript/Java/.Net/Python/PHP",
   "keywords": [


### PR DESCRIPTION
The current tracing skips anything that `AsServiceError` does afterwards.

@psstoev 